### PR TITLE
Feature/reust-26: email user upon register & forgot-password

### DIFF
--- a/src/app/auth/auth.controller.ts
+++ b/src/app/auth/auth.controller.ts
@@ -56,7 +56,7 @@ export class AuthController {
             newUser?.id,
             newUser?.userType?.name,
         );
-        const resetPasswordUrl = `${process.env.HOST}/forgot-password/${newAuth.resetToken}`; // TODO: generate realtime host
+        const resetPasswordUrl = `${process.env.HOST}/forgot-password/${newAuth.resetToken}`;
 
         return {
             id: newUser.id,

--- a/src/app/auth/auth.controller.ts
+++ b/src/app/auth/auth.controller.ts
@@ -32,7 +32,7 @@ export class AuthController {
             throw new UnauthorizedException('Unauthorized user.');
         }
 
-        const userToken = this.authService.generateToken(
+        const userToken = this.authService.generateJwtToken(
             user.id,
             user.userType.name,
         );
@@ -49,11 +49,16 @@ export class AuthController {
         );
 
         if (existingUser) {
-            throw new ExistsException('User code exist.');
+            throw new ExistsException(`User code '${body.userCode}' exist.`);
         }
 
         const newUser = await this.userService.create(body);
         const resetPasswordUrl = `${process.env.HOST}/forgot-password/${newUser.id}`; // TODO: need to generate a correct URL for reset password
+
+        await this.authService.generateAuth(
+            newUser?.id,
+            newUser?.userType?.name,
+        );
 
         return {
             id: newUser.id,
@@ -83,7 +88,7 @@ export class AuthController {
         const updatedUser = await this.userService.update(user, {
             password: body.password,
         } as UpdateUserDto);
-        const userToken = this.authService.generateToken(
+        const userToken = this.authService.generateJwtToken(
             updatedUser.id,
             updatedUser.userType.name,
         );

--- a/src/app/auth/auth.module.ts
+++ b/src/app/auth/auth.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserModule } from '../user/user.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { AuthEntity } from './repository/auth.entity';
 
 @Module({
-    imports: [UserModule],
+    imports: [TypeOrmModule.forFeature([AuthEntity]), UserModule],
     controllers: [AuthController],
     providers: [AuthService],
 })

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -48,4 +48,17 @@ export class AuthService {
 
         return this.authRepository.save(newAuth);
     }
+
+    async resetPassword(
+        authId: number,
+        newPassword: string,
+    ): Promise<AuthEntity> {
+        const auth = await this.authRepository.findOne(authId);
+
+        return this.authRepository.save({
+            id: auth.id,
+            password: newPassword,
+            resetToken: null,
+        });
+    }
 }

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -1,11 +1,51 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import * as jwt from 'jsonwebtoken';
+import { Repository } from 'typeorm';
+import { AuthEntity } from './repository/auth.entity';
 
 @Injectable()
 export class AuthService {
-    generateToken(userId: number, userType: string): string {
+    constructor(
+        @InjectRepository(AuthEntity)
+        private readonly authRepository: Repository<AuthEntity>,
+    ) {}
+
+    generateJwtToken(userId: number, userType: string): string {
         return jwt.sign({ userId, userType }, process.env.APP_API_SECRET, {
             expiresIn: '24h',
         });
+    }
+
+    generateResetToken(userId: number, userType: string): string {
+        return jwt.sign({ userId, userType }, process.env.APP_API_SECRET, {
+            expiresIn: '1h',
+        });
+    }
+
+    async findByResetToken(resetToken: string): Promise<AuthEntity> {
+        return this.authRepository.findOne({ resetToken });
+    }
+
+    async generateAuth(userId: number, userType: string): Promise<AuthEntity> {
+        const auth = await this.authRepository.findOne({ userId });
+
+        let newAuth = null;
+        if (auth) {
+            newAuth = {
+                id: auth.id,
+                userId,
+                password: auth?.password,
+                resetToken: this.generateResetToken(userId, userType),
+            } as AuthEntity;
+        } else {
+            newAuth = {
+                userId,
+                password: 'new password',
+                resetToken: this.generateResetToken(userId, userType),
+            } as AuthEntity;
+        }
+
+        return this.authRepository.save(newAuth);
     }
 }

--- a/src/app/auth/repository/auth.entity.ts
+++ b/src/app/auth/repository/auth.entity.ts
@@ -1,0 +1,40 @@
+import { Expose } from 'class-transformer';
+import { UserEntity } from 'src/app/user/repository/user.entity';
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    OneToOne,
+    JoinColumn,
+} from 'typeorm';
+
+@Entity('auths')
+export class AuthEntity {
+    @PrimaryGeneratedColumn()
+    @Expose()
+    id: number;
+
+    @Column({ name: 'user_id' })
+    @Expose()
+    userId: number;
+
+    @Column({ name: 'password' })
+    @Expose()
+    password: string;
+
+    @Column({ name: 'reset_token' })
+    @Expose()
+    resetToken: string;
+
+    @Column({ name: 'created_at' })
+    @Expose()
+    createdAt: Date;
+
+    @Column({ name: 'updated_at' })
+    @Expose()
+    updatedAt: Date;
+
+    @OneToOne(() => UserEntity, { eager: true })
+    @JoinColumn({ name: 'user_id' })
+    authUser: UserEntity;
+}

--- a/src/database/migrations/1617900035590-AddAuthTable.ts
+++ b/src/database/migrations/1617900035590-AddAuthTable.ts
@@ -1,0 +1,62 @@
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableForeignKey,
+} from 'typeorm';
+
+export class AddAuthTable1617900035590 implements MigrationInterface {
+    async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'auths',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    {
+                        name: 'user_id',
+                        type: 'int',
+                    },
+                    {
+                        name: 'password',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'reset_token',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'created_at',
+                        type: 'timestamp',
+                        default: 'CURRENT_TIMESTAMP',
+                    },
+                    {
+                        name: 'updated_at',
+                        type: 'timestamp',
+                        isNullable: true,
+                        onUpdate: 'CURRENT_TIMESTAMP',
+                    },
+                ],
+            }),
+            true,
+        );
+
+        await queryRunner.createForeignKey(
+            'auths',
+            new TableForeignKey({
+                columnNames: ['user_id'],
+                referencedColumnNames: ['id'],
+                referencedTableName: 'users',
+            }),
+        );
+    }
+
+    async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('auths');
+    }
+}

--- a/src/database/migrations/1617900035590-AddAuthTable.ts
+++ b/src/database/migrations/1617900035590-AddAuthTable.ts
@@ -29,6 +29,8 @@ export class AddAuthTable1617900035590 implements MigrationInterface {
                     {
                         name: 'reset_token',
                         type: 'varchar',
+                        isNullable: true,
+                        default: null,
                     },
                     {
                         name: 'created_at',


### PR DESCRIPTION
Send email to user after calling these endpoints:
[POST] /auth/register
- check user code exist
- create user record
- create auth record by user id
- generate random password
- generate password reset token
- return new user

[POST] /auth/forgot-password/:resetToken
- check auth record by reset token
- set new password
- return user

Create 'auth' table to store:
- user_id
- password
- reset_token
